### PR TITLE
Order Filtering

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -286,7 +286,7 @@ app.MapGet("/styles", () =>
     });
 });
 
-app.MapGet("/orders", () =>
+app.MapGet("/orders", (int? paintId) =>
 {
     List<OrderDTO> orderDTOs = new List<OrderDTO>();
 
@@ -346,7 +346,14 @@ app.MapGet("/orders", () =>
         }
     }
 
-    return Results.Ok(orderDTOs);
+    List<OrderDTO> filteredOrders = orderDTOs;
+
+    if (paintId != null)
+    {
+        filteredOrders = filteredOrders.Where(order => order.PaintId == paintId).ToList();
+    }
+
+    return Results.Ok(filteredOrders);
 });
 
 app.MapPost("/orders", (Order order) =>

--- a/Program.cs
+++ b/Program.cs
@@ -288,6 +288,11 @@ app.MapGet("/styles", () =>
 
 app.MapGet("/orders", (int? paintId) =>
 {
+    if (paintId != null & paintColors.FirstOrDefault(paintColor => paintColor.Id == paintId) == null)
+    {
+        return Results.BadRequest();
+    }
+    
     List<OrderDTO> orderDTOs = new List<OrderDTO>();
 
     foreach (Order order in orders)


### PR DESCRIPTION
### Purpose
To allow users to get a list of orders that are filtered by their paintId

### Files Changed
- Updated orders GET endpoint to accept query param to filter by paint Id in `Program.cs`

### To Test
Fetch, and run "dotnet watch run"
- Confirm orders GET endpoint still works as intended
- Confirm orders with query param for a paintId provides only unfulfilled orders with a matching paintId